### PR TITLE
[feature] parseBuffer => ParseReader - now exported.

### DIFF
--- a/goyesql.go
+++ b/goyesql.go
@@ -19,7 +19,7 @@ func ParseFile(path string) (Queries, error) {
 	}
 	defer file.Close()
 
-	return parseBuffer(file)
+	return ParseReader(file)
 }
 
 // MustParseFile calls ParseFile but panic if an error occurs

--- a/scanner.go
+++ b/scanner.go
@@ -24,7 +24,8 @@ type Tag string
 // Queries is a map associating a Tag to its Query
 type Queries map[Tag]Query
 
-func parseBuffer(reader io.Reader) (Queries, error) {
+// ParseReader takes an io.Reader and returns Queries or an error.
+func ParseReader(reader io.Reader) (Queries, error) {
 	var (
 		lastTag  Tag
 		lastLine parsedLine


### PR DESCRIPTION
I've exposed `ParseReader` (nee `parseBuffer`) here as it ties in better with embed-file-in-binary libraries and/or cases where you may wish to perform your own reads - passing the result of `os.Open` to another package that uses `goyesql`. 

(plus exposing Go's io interfaces is a useful idiom!)
